### PR TITLE
Use better URI quoting characters in ticket change reporter

### DIFF
--- a/twisted_trac_plugins/ticket_reporter.py
+++ b/twisted_trac_plugins/ticket_reporter.py
@@ -25,19 +25,19 @@ class IRCTicketObserver(Component):
             new = ticket.values['keywords']
             if 'review' in old and 'review' not in new:
                 # It was up for review, now it isn't
-                messages.append('%(author)s reviewed [https://tm.tl/#%(ticket)d] - %(summary)s (%(assignee)s)')
+                messages.append('%(author)s reviewed <https://tm.tl/#%(ticket)d> - %(summary)s (%(assignee)s)')
             elif 'review' in new and 'review' not in old:
                 # It is up for review, and it wasn't before
-                messages.append('%(author)s submitted [https://tm.tl/#%(ticket)d] - %(summary)s (%(assignee)s) for review')
+                messages.append('%(author)s submitted <https://tm.tl/#%(ticket)d> - %(summary)s (%(assignee)s) for review')
         old = old_values.get('status', None)
         if old is not None:
             new = ticket.values['status']
             if old != 'closed' and new == 'closed':
                 # It wasn't closed, now it is.
-                messages.append('%(author)s closed [https://tm.tl/#%(ticket)d] - %(summary)s')
+                messages.append('%(author)s closed <https://tm.tl/#%(ticket)d> - %(summary)s')
             elif old == 'closed' and new != 'closed':
                 # It was closed, now it isn't.
-                messages.append('%(author)s re-opened [https://tm.tl/#%(ticket)d] - %(summary)s')
+                messages.append('%(author)s re-opened <https://tm.tl/#%(ticket)d> - %(summary)s')
         if messages is not None:
             assignee = 'unassigned'
             if ticket.values['owner']:


### PR DESCRIPTION
Currently ticket URIs are quoted with square brackets `[]`, which may look pretty but are unfortunately annoying because they're reserved characters and not intended for use as delimiting a URI in context; from [RFC3896](https://tools.ietf.org/html/rfc3986#section-2.2):

> If data for a URI component would conflict with a reserved
> character's purpose as a delimiter, then the conflicting data must be
> percent-encoded before the URI is formed.

[Recommended ways](https://tools.ietf.org/html/rfc3986#appendix-C) of delimiting a URI in context are: Double-quotes `""`, whitespace or, my personal favourite, angle brackets `<>`.
