### PR TITLE
Handle OSX's md5sum -r being slightly different to GNU Coreutils

### DIFF
--- a/twisted_trac_plugins/release_macro.py
+++ b/twisted_trac_plugins/release_macro.py
@@ -57,7 +57,7 @@ class VersionInformation(object):
             base=self.version.base(), md5="")
         filename = path.split('/')[-1]
         for entry in lines[3:lines.index(sep)]:
-            entry = entry.rstrip('\n').split('  ')
+            entry = entry.rstrip('\n').split(' ')
             if entry[-1] == filename:
                 return entry[0]
         return ''


### PR DESCRIPTION
OS X's md5sum uses one space inbetween the sum and filename, not two. Since they both have two items, we can handle both by just fetching the first and last item.
